### PR TITLE
Changed psycopg2 to use the new binary to remove the 2.8 deprecation …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'psycopg2',
+        'psycopg2-binary',
     ],
 
     extras_require={


### PR DESCRIPTION
* psycopg2 is going to use psycopg2-binary going forward so it raises an error in my project