### PR TITLE
[fix] fix the depreciated staticfiles & support extended foreignkeys

### DIFF
--- a/foreignform/mixins.py
+++ b/foreignform/mixins.py
@@ -1,6 +1,13 @@
 import json
-
+from functools import reduce
 from django.core.exceptions import FieldDoesNotExist
+
+
+def rgetattr(obj, attr, *args):
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return reduce(_getattr, [obj] + attr.split("."))
 
 
 class ForeignFormAdminMixin(object):
@@ -13,7 +20,7 @@ class ForeignFormAdminMixin(object):
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         instance = self.model.objects.get(id=object_id)
-        fk = getattr(instance, self.foreignform_foreign_key, None)
+        fk = rgetattr(instance, self.foreignform_foreign_key)
 
         if not fk:
             raise FieldDoesNotExist(

--- a/foreignform/templates/foreignform/add.html
+++ b/foreignform/templates/foreignform/add.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load staticfiles %}
+{% load static %}
 
 
 {% block admin_change_form_document_ready %}
@@ -8,10 +8,10 @@
   window.foreignformField = '{{ foreignform_field }}';
   window.foreignformForeignKey = '{{ foreignform_foreign_key }}';
 </script>
-<script src="{%static 'foreignform/js/main-add.js'%}"></script>
+<script src="{% static 'foreignform/js/main-add.js'%}"></script>
 {% endblock %}
 
 {% block extrahead %}
 {{ block.super }}
-<link rel="stylesheet" href="{%static 'foreignform/css/main-add.css'%}">
+<link rel="stylesheet" href="{% static 'foreignform/css/main-add.css'%}">
 {% endblock %}

--- a/foreignform/templates/foreignform/change.html
+++ b/foreignform/templates/foreignform/change.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block admin_change_form_document_ready %}
 {{ block.super }}
@@ -8,7 +8,7 @@
   window.foreignformJSONSchema = {{foreignform_JSONSchema|safe}};
   window.foreignformUISchema = {{foreignform_UISchema|safe}};
 </script>
-<script src="{%static 'foreignform/js/main-change.js'%}"></script>
+<script src="{% static 'foreignform/js/main-change.js'%}"></script>
 {% endblock %}
 
 {% block after_field_sets %}
@@ -18,5 +18,5 @@
 
 {% block extrahead %}
 {{ block.super }}
-<link rel="stylesheet" href="{%static 'foreignform/css/main-change.css'%}">
+<link rel="stylesheet" href="{% static 'foreignform/css/main-change.css'%}">
 {% endblock %}


### PR DESCRIPTION
This PR contains 2 fixes:

1) remove the depreciated `staticfiles` in favor to `static`
2) provide the ability to have extended foreignkey (eg, `foreignform_foreign_key = "field_fk1.field_fk2.template"`